### PR TITLE
Add systemd support

### DIFF
--- a/euca-WSDL2C.sh
+++ b/euca-WSDL2C.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if grep -q linux:6 /etc/system-release-cpe; then
-    # Don't use uname or builds in chroots will behave poorly
-    CLASSPATH=$(build-classpath axis2 backport-util-concurrent commons-logging ws-commons-axiom ws-commons-XmlSchema ws-commons-neethi wsdl4j xalan-j2 xsltc) exec java org.apache.axis2.wsdl.WSDL2C $*
-else
-    CLASSPATH=$(build-classpath axiom axis2 commons-logging neethi wsdl4j xalan-j2 xalan-j2-serializer xalan-j2-xsltc XmlSchema) exec java org.apache.axis2.wsdl.WSDL2C $*
-fi

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -466,9 +466,6 @@ install -d -m 0771 $RPM_BUILD_ROOT/var/lib/eucalyptus/instances
 install -d -m 0755 $RPM_BUILD_ROOT/var/run/eucalyptus/net
 install -d -m 0750 $RPM_BUILD_ROOT/var/run/eucalyptus/status
 
-# Touch httpd config files that the init scripts create so we can %ghost them
-touch $RPM_BUILD_ROOT/var/run/eucalyptus/httpd-{cc,nc,tmp}.conf
-
 # Put udev rules in the right place
 mkdir -p $RPM_BUILD_ROOT/lib/udev/rules.d
 cp -p $RPM_BUILD_ROOT/usr/share/eucalyptus/udev/rules.d/12-dm-permissions.rules $RPM_BUILD_ROOT/lib/udev/rules.d/12-dm-permissions.rules
@@ -542,7 +539,6 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 # CC and NC
 /etc/eucalyptus/httpd.conf
 /usr/share/eucalyptus/policies
-%ghost /var/run/eucalyptus/httpd-tmp.conf
 /usr/share/eucalyptus/euca_ipt
 /usr/share/eucalyptus/floppy
 /usr/share/eucalyptus/populate_arp.pl
@@ -622,7 +618,6 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 %defattr(-,root,root,-)
 %{axis2c_home}/services/EucalyptusCC/
 %attr(-,eucalyptus,eucalyptus) %dir /var/lib/eucalyptus/CC
-%ghost /var/run/eucalyptus/httpd-cc.conf
 /usr/lib/eucalyptus/shutdownCC
 /usr/sbin/clusteradmin-*
 /usr/sbin/eucalyptus-cluster
@@ -644,7 +639,6 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 /etc/eucalyptus/nc-hooks/example.sh
 %{axis2c_home}/services/EucalyptusNC/
 %attr(-,eucalyptus,eucalyptus) %dir /var/lib/eucalyptus/instances
-%ghost /var/run/eucalyptus/httpd-nc.conf
 /usr/sbin/euca_test_nc
 /usr/sbin/eucalyptus-node
 /usr/share/eucalyptus/authorize-migration-keys.pl
@@ -961,6 +955,7 @@ usermod -a -G libvirt eucalyptus || :
 - Switched to stock eucalyptus.conf defaults
 - Switched to eucalyptus-provided euca-WSDL2C.sh
 - Added main executables for CC and NC
+- Stopped tracking temporary CC and NC httpd config files
 
 * Thu Jan 21 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Depend on unversioned postgresql packages for RHEL 7

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -625,6 +625,7 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 %ghost /var/run/eucalyptus/httpd-cc.conf
 /usr/lib/eucalyptus/shutdownCC
 /usr/sbin/clusteradmin-*
+/usr/sbin/eucalyptus-cluster
 /usr/share/eucalyptus/vtunall.conf.template
 /usr/share/eucalyptus/dynserv.pl
 /usr/share/eucalyptus/getstats_net.pl
@@ -645,6 +646,7 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 %attr(-,eucalyptus,eucalyptus) %dir /var/lib/eucalyptus/instances
 %ghost /var/run/eucalyptus/httpd-nc.conf
 /usr/sbin/euca_test_nc
+/usr/sbin/eucalyptus-node
 /usr/share/eucalyptus/authorize-migration-keys.pl
 /usr/share/eucalyptus/detach.pl
 /usr/share/eucalyptus/gen_kvm_libvirt_xml
@@ -958,6 +960,7 @@ usermod -a -G libvirt eucalyptus || :
 - Added systemd files
 - Switched to stock eucalyptus.conf defaults
 - Switched to eucalyptus-provided euca-WSDL2C.sh
+- Added main executables for CC and NC
 
 * Thu Jan 21 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Depend on unversioned postgresql packages for RHEL 7

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -916,6 +916,7 @@ usermod -a -G libvirt eucalyptus || :
 
 %post -n eucanetd
 %systemd_post eucanetd.service
+sysctl --system
 
 %preun common-java
 %systemd_preun eucalyptus-cloud.service
@@ -928,6 +929,7 @@ usermod -a -G libvirt eucalyptus || :
 
 %preun -n eucanetd
 %systemd_preun eucanetd.service
+sysctl --system
 
 %postun common-java
 %systemd_postun
@@ -947,6 +949,7 @@ usermod -a -G libvirt eucalyptus || :
 %changelog
 * Mon Feb  8 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Removed old cruft
+- Started loading sysctl values where needed on RHEL 7
 
 * Wed Feb  3 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Added systemd scriptlets

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -876,7 +876,7 @@ exit 0
 
 %pre
 getent group eucalyptus >/dev/null || groupadd -r eucalyptus
-getent group eucalyptus-status >/dev/null || groupadd -r eucalyptus
+getent group eucalyptus-status >/dev/null || groupadd -r eucalyptus-status
 getent passwd eucalyptus >/dev/null || \
     useradd -r -g eucalyptus -d /var/lib/eucalyptus -s /sbin/nologin \
     -c 'Eucalyptus cloud' eucalyptus

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -915,8 +915,8 @@ usermod -a -G libvirt eucalyptus || :
 
 %post -n eucanetd
 %systemd_post eucanetd.service
-/usr/lib/systemd/systemd-modules-load
-sysctl --system >/dev/null
+/usr/lib/systemd/systemd-modules-load || :
+sysctl --system >/dev/null || :
 
 %preun common-java
 %systemd_preun eucalyptus-cloud.service
@@ -929,8 +929,8 @@ sysctl --system >/dev/null
 
 %preun -n eucanetd
 %systemd_preun eucanetd.service
-/usr/lib/systemd/systemd-modules-load
-sysctl --system >/dev/null
+/usr/lib/systemd/systemd-modules-load || :
+sysctl --system >/dev/null || :
 
 %postun common-java
 %systemd_postun

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -70,8 +70,6 @@ BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 Source0:       %{tarball_basedir}.tar.xz
 Source1:       %{cloud_lib_tarball}
-# A version of WSDL2C.sh that respects standard classpaths
-Source2:       euca-WSDL2C.sh
 
 %description
 Eucalyptus is a service overlay that implements elastic computing
@@ -438,9 +436,9 @@ export CFLAGS="%{optflags}"
 # Eucalyptus does not assign the usual meaning to prefix and other standard
 # configure variables, so we can't realistically use %%configure.
 %if 0%{?el6}
-./configure --with-axis2=%{_datadir}/axis2-* --with-axis2c=%{axis2c_home} --with-wsdl2c-sh=%{S:2} --enable-debug --prefix=/ --with-apache2-module-dir=%{_libdir}/httpd/modules --enable-sysvinit --with-db-home=/usr/pgsql-9.2 --with-extra-version=%{release}
+./configure --with-axis2=%{_datadir}/axis2-* --with-axis2c=%{axis2c_home} --with-wsdl2c-sh="$(pwd)/devel/euca-WSDL2C.sh" --enable-debug --prefix=/ --with-apache2-module-dir=%{_libdir}/httpd/modules --enable-sysvinit --with-db-home=/usr/pgsql-9.2 --with-extra-version=%{release}
 %else
-./configure --with-axis2=%{_datadir}/axis2-* --with-axis2c=%{axis2c_home} --with-wsdl2c-sh=%{S:2} --enable-debug --prefix=/ --with-apache2-module-dir=%{_libdir}/httpd/modules --enable-systemd --with-db-home=%{_prefix} --with-extra-version=%{release}
+./configure --with-axis2=%{_datadir}/axis2-* --with-axis2c=%{axis2c_home} --with-wsdl2c-sh="$(pwd)/devel/euca-WSDL2C.sh" --enable-debug --prefix=/ --with-apache2-module-dir=%{_libdir}/httpd/modules --enable-systemd --with-db-home=%{_prefix} --with-extra-version=%{release}
 %endif
 
 # Untar the bundled cloud-lib Java dependencies.
@@ -483,9 +481,6 @@ rm -rf $RPM_BUILD_ROOT/usr/share/eucalyptus/udev
 # Store admin tool config files
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/eucalyptus-admin
 cp -Rp admin-tools/conf/* $RPM_BUILD_ROOT/%{_sysconfdir}/eucalyptus-admin
-
-# Remove README file if one exists
-rm -f $RPM_BUILD_ROOT/usr/share/eucalyptus/README
 
 %if 0%{?el6}
 # Eucalyptus's build scripts do not respect initrddir
@@ -962,6 +957,7 @@ usermod -a -G libvirt eucalyptus || :
 - Added systemd scriptlets
 - Added systemd files
 - Switched to stock eucalyptus.conf defaults
+- Switched to eucalyptus-provided euca-WSDL2C.sh
 
 * Thu Jan 21 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Depend on unversioned postgresql packages for RHEL 7

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -652,8 +652,6 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 %attr(-,eucalyptus,eucalyptus) /var/lib/eucalyptus/.libvirt/
 /var/lib/polkit-1/localauthority/10-vendor.d/eucalyptus-nc-libvirt.pkla
 %else
-# Note that modules-load.d is not processed by default on el7, so we
-# still have to load it in the eucalyptus-node executable
 /usr/lib/modules-load.d/70-eucalyptus-node.conf
 %{_unitdir}/eucalyptus-node.service
 %{_unitdir}/eucalyptus-node-keygen.service
@@ -727,6 +725,7 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 %if 0%{?el6}
 %{_initrddir}/eucanetd
 %else
+/usr/lib/modules-load.d/70-eucanetd.conf
 %{_sysctldir}/70-eucanetd.conf
 %{_unitdir}/eucanetd.service
 %endif
@@ -916,6 +915,7 @@ usermod -a -G libvirt eucalyptus || :
 
 %post -n eucanetd
 %systemd_post eucanetd.service
+/usr/lib/systemd/systemd-modules-load
 sysctl --system >/dev/null
 
 %preun common-java
@@ -929,6 +929,7 @@ sysctl --system >/dev/null
 
 %preun -n eucanetd
 %systemd_preun eucanetd.service
+/usr/lib/systemd/systemd-modules-load
 sysctl --system >/dev/null
 
 %postun common-java
@@ -950,6 +951,7 @@ sysctl --system >/dev/null
 * Mon Feb  8 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Removed old cruft
 - Started loading sysctl values where needed on RHEL 7
+- Started loading modules where needed on RHEL 7
 
 * Wed Feb  3 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Added systemd scriptlets

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -66,8 +66,6 @@ BuildRequires: systemd
 
 Requires(pre): shadow-utils
 
-BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-
 Source0:       %{tarball_basedir}.tar.xz
 Source1:       %{cloud_lib_tarball}
 
@@ -448,12 +446,10 @@ tar xf %{SOURCE1} -C clc/lib
 # Don't bother with git since we're using a cloud-libs tarball
 touch clc/.nogit
 
-# FIXME: storage/Makefile breaks with parallel make
-make # %{?_smp_mflags}
+make %{?_smp_mflags}
 
 
 %install
-[ $RPM_BUILD_ROOT != "/" ] && rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
 
 # Create the directories where components store their data
@@ -949,6 +945,9 @@ usermod -a -G libvirt eucalyptus || :
 
 
 %changelog
+* Mon Feb  8 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
+- Removed old cruft
+
 * Wed Feb  3 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Added systemd scriptlets
 - Added systemd files

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -624,6 +624,7 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 %if 0%{?el6}
 %{_initrddir}/eucalyptus-cc
 %else
+%{_unitdir}/eucalyptus-cc.service
 %{_unitdir}/eucalyptus-cluster.service
 %endif
 
@@ -654,6 +655,7 @@ touch $RPM_BUILD_ROOT/var/lib/eucalyptus/.libvirt/libvirtd.conf
 /var/lib/polkit-1/localauthority/10-vendor.d/eucalyptus-nc-libvirt.pkla
 %else
 /usr/lib/modules-load.d/70-eucalyptus-node.conf
+%{_unitdir}/eucalyptus-nc.service
 %{_unitdir}/eucalyptus-node.service
 %{_unitdir}/eucalyptus-node-keygen.service
 %endif
@@ -948,6 +950,9 @@ sysctl --system >/dev/null || :
 
 
 %changelog
+* Wed Feb 10 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
+- Added compatibility symlinks for eucalyptus-cluster/node systemd units
+
 * Tue Feb  9 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Don't install euca-imager
 - Added seabios dependency to nc package (EUCA-12003)

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -916,7 +916,7 @@ usermod -a -G libvirt eucalyptus || :
 
 %post -n eucanetd
 %systemd_post eucanetd.service
-sysctl --system
+sysctl --system >/dev/null
 
 %preun common-java
 %systemd_preun eucalyptus-cloud.service
@@ -929,7 +929,7 @@ sysctl --system
 
 %preun -n eucanetd
 %systemd_preun eucanetd.service
-sysctl --system
+sysctl --system >/dev/null
 
 %postun common-java
 %systemd_postun

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -458,12 +458,6 @@ make # %{?_smp_mflags}
 [ $RPM_BUILD_ROOT != "/" ] && rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
 
-sed -i -e 's#.*EUCALYPTUS=.*#EUCALYPTUS="/"#' \
-       -e 's#.*HYPERVISOR=.*#HYPERVISOR="kvm"#' \
-       -e 's#.*INSTANCE_PATH=.*#INSTANCE_PATH="/var/lib/eucalyptus/instances"#' \
-       -e 's#.*VNET_BRIDGE=.*#VNET_BRIDGE="br0"#' \
-       $RPM_BUILD_ROOT/etc/eucalyptus/eucalyptus.conf
-
 # Eucalyptus's build scripts do not respect initrddir
 if [ %{_initrddir} != /etc/init.d ]; then
     mkdir -p $RPM_BUILD_ROOT/%{_initrddir}
@@ -967,6 +961,7 @@ usermod -a -G libvirt eucalyptus || :
 * Wed Feb  3 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Added systemd scriptlets
 - Added systemd files
+- Switched to stock eucalyptus.conf defaults
 
 * Thu Jan 21 2016 Eucalyptus Release Engineering <support@eucalyptus.com> - 4.3.0
 - Depend on unversioned postgresql packages for RHEL 7


### PR DESCRIPTION
This patch set adds the relevant --enable-sysvinit or --enable-systemd configure-time options to el6-based and el7-based builds, respectively.  It then handles the differences in file lists and package scripts between the two sets of artifacts, adds the main executables introduced in that branch, and finally includes a little cleanup.  This goes with a matching eucalyptus pull request, eucalyptus/eucalyptus#51.