### PR TITLE
On el6 the java devel package contains the /usr/lib/jvm/java-1.8.0

### DIFF
--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -157,6 +157,7 @@ Requires:     jpackage-utils
 Requires:     java-1.8.0-openjdk >= 1:1.8.0
 %if ! 0%{?el6}
 Requires:     eucalyptus-selinux
+Requires:     java-1.8.0-openjdk-devel >= 1:1.8.0
 %endif
 
 %description common-java-libs


### PR DESCRIPTION
to be present. We were only requiring this as BuildRequires: before,
now we will Require: it for installation too.