### PR TITLE
EUCA-13122 Add installation of script to fix snapshot point IDs for cloud admins to run manually if needed (normally run at SC init time).

### DIFF
--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -540,6 +540,7 @@ cp -Rp admin-tools/conf/* $RPM_BUILD_ROOT/%{_sysconfdir}/eucalyptus-admin
 
 %files sc
 %attr(-,eucalyptus,eucalyptus) %dir /var/lib/eucalyptus/volumes
+/usr/share/eucalyptus/PopulateSnapPoints.groovy
 
 
 %files cc


### PR DESCRIPTION
I tried to build RPMs with this change, but I get unrelated errors about cassandra, so I have not been able to test this change.

See also https://github.com/eucalyptus/eucalyptus/pull/93

@gholms: How does it look?
