### PR TITLE
EUCA-13122 Add installation of script to fix snapshot point IDs

### DIFF
--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -540,6 +540,7 @@ cp -Rp admin-tools/conf/* $RPM_BUILD_ROOT/%{_sysconfdir}/eucalyptus-admin
 
 %files sc
 %attr(-,eucalyptus,eucalyptus) %dir /var/lib/eucalyptus/volumes
+/usr/share/eucalyptus/PopulateSnapPoints.groovy
 
 
 %files cc

--- a/eucalyptus.spec
+++ b/eucalyptus.spec
@@ -698,6 +698,9 @@ usermod -a -G libvirt eucalyptus || :
 
 
 %changelog
+* Tue Jan 31 2017 Lincoln Thomas <lincoln.thomas@hpe.com> - 4.4.0
+- Install new PopulateSnapPoints.groovy script (EUCA-13122)
+
 * Fri Jan 20 2017 Garrett Holmstrom <gholms@fedoraproject.org> - 4.4.0
 - Moved euca-upgrade script to the same package as its systemd unit (EUCA-13139)
 - Bumped minimum eucalyptus-java-deps version


### PR DESCRIPTION
... for cloud admins to run manually if needed (normally run at SC init time).

(Corrected from previous PR to merge into maint-4.4)

I tried to build RPMs with this change, but I get unrelated errors about cassandra, so I have not been able to test this change.

See also eucalyptus/eucalyptus#93

@gholms: How does it look?